### PR TITLE
Add requests_cache

### DIFF
--- a/bot/project.cfg
+++ b/bot/project.cfg
@@ -1,5 +1,5 @@
 repo="boardgamebot"
-tag="0.9.3"
+tag="0.9.4"
 name="bgbot"
 
 # NB:

--- a/bot/python/online_game_search.py
+++ b/bot/python/online_game_search.py
@@ -4,7 +4,17 @@ import html
 import requests
 import time
 import difflib
+import requests_cache
 from bs4 import BeautifulSoup
+
+requests_cache.install_cache(
+    cache_name='cache',
+    backend='memory',
+    expire_after=86400,
+    allowable_codes=(200, ),
+    allowable_methods=('GET', ),
+    old_data_on_error=False,
+)
 
 
 class Webpage(BeautifulSoup):

--- a/bot/python/requirements.txt
+++ b/bot/python/requirements.txt
@@ -11,6 +11,7 @@ idna==2.10
 multidict==4.7.6
 python-dotenv==0.14.0
 requests==2.24.0
+requests-cache==0.5.2
 soupsieve==2.0.1
 urllib3==1.25.10
 yarl==1.6.0


### PR DESCRIPTION
Uses [requests_cache](https://requests-cache.readthedocs.io/en/latest/) to cache url searches for 24 hours. This speeds up repeated searches for the same game and, more importantly, means the additional GET requests for navigating through a game embed are removed. This speeds up the embed navigation significantly.

Thanks to @ElectricWarr for working out the solution.